### PR TITLE
add NSX overall status check with feature flag

### DIFF
--- a/zpodengine/src/zpodengine/zpod_component_add/zpod_component_add_4_post_scripts.py
+++ b/zpodengine/src/zpodengine/zpod_component_add/zpod_component_add_4_post_scripts.py
@@ -146,6 +146,17 @@ def zpod_component_add_post_scripts(*, zpod_component_id: int):
                                 raise ValueError(
                                     f"NSX management cluster status is {nsx_status}"
                                 )
+                            if DBUtils.get_setting_value("ff_component_wait_for_status") == "true":
+                                nsx_overall_status = (
+                                    response.safejson()
+                                    .get("detailed_cluster_status")
+                                    .get("overall_status")
+                                )
+                                print(f"NSX overall cluster status is {nsx_status}")
+                                if nsx_overall_status != "STABLE":
+                                    raise ValueError(
+                                        f"NSX overall cluster status is {nsx_status}"
+                                    )
                             nsx_is_ready = True
                             break
                         except (RequestError, HTTPStatusError) as e:


### PR DESCRIPTION
## Description
This PR adds an additional check for component status during addition, starting with NSX cluster. This feature is controlled by the `ff_component_wait_for_status` feature flag.

### Feature Flag
- Name: `ff_component_wait_for_status`
- Default value: `false`
- Description: Enables component status verification during addition

## Impact
This change ensures that components are in a stable state before proceeding with addition, reducing deployment risks. Currently implemented for NSX, this pattern will be extended to other components in future PRs.