### PR TITLE
Adding sample config_scripts

### DIFF
--- a/zpodengine/src/zpodengine/config_scripts/sample/zpod_component_add_zbox.py
+++ b/zpodengine/src/zpodengine/config_scripts/sample/zpod_component_add_zbox.py
@@ -1,0 +1,18 @@
+from zpodcommon import models as M
+from zpodengine.lib import database
+
+
+def execute_config_script(
+    zpod_component_id: int,
+) -> None:
+    """
+    Sample config script
+
+    Args:
+        zpod_component_id: The zPod component ID
+    """
+
+    with database.get_session_ctx() as session:
+        zpod_component = session.get(M.ZpodComponent, zpod_component_id)
+        zpod = zpod_component.zpod
+        print(f"This is just a sample config script doing nothing for zPod {zpod.name} and zPod component {zpod_component.component.component_name}")

--- a/zpodengine/src/zpodengine/config_scripts/sample/zpod_deploy.py
+++ b/zpodengine/src/zpodengine/config_scripts/sample/zpod_deploy.py
@@ -1,0 +1,18 @@
+from zpodcommon import models as M
+from zpodengine.lib import database
+
+
+def execute_config_script(
+    zpod_id: int,
+) -> None:
+    """
+    Sample config script
+
+    Args:
+        zpod_id: The zPod ID
+    """
+
+    with database.get_session_ctx() as session:
+        zpod = session.get(M.Zpod, zpod_id)
+        print(f"This is just a sample config script doing nothing for zPod {zpod.name}")
+

--- a/zpodengine/src/zpodengine/config_scripts/sample/zpod_destroy.py
+++ b/zpodengine/src/zpodengine/config_scripts/sample/zpod_destroy.py
@@ -1,0 +1,18 @@
+from zpodcommon import models as M
+from zpodengine.lib import database
+
+
+def execute_config_script(
+    zpod_id: int,
+) -> None:
+    """
+    Sample config script
+
+    Args:
+        zpod_id: The zPod ID
+    """
+
+    with database.get_session_ctx() as session:
+        zpod = session.get(M.Zpod, zpod_id)
+        print(f"This is just a sample config script doing nothing for zPod {zpod.name}")
+


### PR DESCRIPTION
## Description
This PR adds sample config scripts.

The config-scripts system allows execution of custom scripts at different stages of a zPod's lifecycle:
   - After component deployment
   - After complete zPod deployment
   - After zPod destruction

### Folder Structure
Scripts are organized in:
- `/zpodengine/src/zpodengine/config_scripts/{feature_name}/`: Directory containing feature-specific scripts
  - `zpod_deploy.py`: Executed after zPod deployment
  - `zpod_component_add_{component_name}.py`: Executed after component deployment
  - `zpod_destroy.py`: Executed after zPod destruction

### Configuration
Scripts to be executed are defined in the zPod features:
```json
{
    "features": {
        "config-scripts": ["feature1", "feature2"]
    }
}
```

Default config-scripts can be configured globally using the `ff_default_config_scripts` setting, which will be applied to all new zPods if no specific config-scripts are provided.