### PR TITLE
zpodapi: zPod permission gate hardening + /permissions/mine endpoint

### DIFF
--- a/zpodapi/src/zpodapi/endpoints/endpoint_enet__routes.py
+++ b/zpodapi/src/zpodapi/endpoints/endpoint_enet__routes.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from zpodapi.endpoints.endpoint__dependencies import EndpointAnnotations
+from zpodapi.lib.global_dependencies import GlobalDepends
 from zpodapi.lib.route_logger import RouteLogger
 
 from .endpoint_enet__dependencies import EndpointENetAnnotations
@@ -51,6 +52,7 @@ def enet_get(
 @router.post(
     "",
     status_code=status.HTTP_201_CREATED,
+    dependencies=[GlobalDepends.OnlySuperAdmin],
 )
 def enet_create(
     *,
@@ -64,6 +66,7 @@ def enet_create(
 @router.delete(
     "/{name}",
     status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[GlobalDepends.OnlySuperAdmin],
 )
 def enet_delete(
     *,

--- a/zpodapi/src/zpodapi/zpods/zpod_component__routes.py
+++ b/zpodapi/src/zpodapi/zpods/zpod_component__routes.py
@@ -59,6 +59,7 @@ def components_add(
     "/{component_id}",
     summary="zPod Component Remove",
     status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[ZpodDepends.ZpodMaintainer],
 )
 def components_remove(
     *,

--- a/zpodapi/src/zpodapi/zpods/zpod_dns__routes.py
+++ b/zpodapi/src/zpodapi/zpods/zpod_dns__routes.py
@@ -14,7 +14,7 @@ router = APIRouter(
     "",
     summary="zPod Dns Get All",
     response_model=list[ZpodDnsView],
-    dependencies=[ZpodDepends.ZpodMaintainer],
+    dependencies=[ZpodDepends.ZpodReader],
 )
 def dns_get_all(
     *,
@@ -28,7 +28,7 @@ def dns_get_all(
     "/{ip}/{hostname}",
     summary="zPod Dns Get",
     response_model=ZpodDnsView,
-    dependencies=[ZpodDepends.ZpodMaintainer],
+    dependencies=[ZpodDepends.ZpodReader],
 )
 def dns_get(
     *,

--- a/zpodapi/src/zpodapi/zpods/zpod_permission__routes.py
+++ b/zpodapi/src/zpodapi/zpods/zpod_permission__routes.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, status
+from fastapi import APIRouter, HTTPException, status
 
 from zpodapi.users.user__schemas import UserView
 from zpodcommon.enums import ZpodPermission
@@ -11,6 +11,7 @@ from .zpod__dependencies import ZpodAnnotations, ZpodDepends
 from .zpod_permission__dependencies import ZpodPermissionAnnotations
 from .zpod_permission__schemas import (
     ZpodPermissionGroupAddRemove,
+    ZpodPermissionMineView,
     ZpodPermissionUserAddRemove,
     ZpodPermissionView,
 )
@@ -31,6 +32,26 @@ def permissions_get_all(
     zpod: ZpodAnnotations.GetZpod,
 ):
     return zpod.permissions
+
+
+@router.get(
+    "/mine",
+    summary="zPod Permission Get Mine",
+    response_model=ZpodPermissionMineView,
+)
+def permissions_get_mine(
+    *,
+    zpod_user_permissions: ZpodAnnotations.GetUserZpodPermissions,
+):
+    for level in (ZpodPermission.ADMIN, ZpodPermission.OWNER, ZpodPermission.USER):
+        if level in zpod_user_permissions:
+            return ZpodPermissionMineView(permission=level)
+    # Unreachable in practice: GetZpod 404s a non-superadmin with no grant, and a
+    # superadmin always holds the virtual ADMIN. Defensive fallback only.
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail="zPod not found",
+    )
 
 
 @router.post(

--- a/zpodapi/src/zpodapi/zpods/zpod_permission__schemas.py
+++ b/zpodapi/src/zpodapi/zpods/zpod_permission__schemas.py
@@ -21,6 +21,11 @@ class ZpodPermissionView(SchemaBase):
     permission_groups: list[PermissionGroupView] = []
 
 
+class ZpodPermissionMineView(SchemaBase):
+    # Caller's highest effective permission on the zPod (ADMIN >= OWNER > USER).
+    permission: enums.ZpodPermission = Field(..., D.permission)
+
+
 class ZpodPermissionUserAddRemove(SchemaBase):
     user_id: int | None = Field(None, D.user_id)
     username: str | None = Field(None, D.username)

--- a/zpodapi/src/zpodapi/zpods/zpod_permission__services.py
+++ b/zpodapi/src/zpodapi/zpods/zpod_permission__services.py
@@ -5,6 +5,35 @@ from zpodapi.lib.service_base import ServiceBase
 from zpodcommon import models as M
 from zpodcommon.enums import ZpodPermission
 
+# Permission levels that keep a zPod manageable by a non-superadmin.
+_MAINTAINER_LEVELS = (ZpodPermission.OWNER, ZpodPermission.ADMIN)
+
+
+def _remaining_maintainer_user_ids(
+    zpod: M.Zpod,
+    *,
+    excluding_user_id: int | None = None,
+    excluding_group_id: int | None = None,
+) -> set[int]:
+    """User ids still holding OWNER/ADMIN on `zpod` once the excluded principal
+    is removed (direct grants + permission-group membership).
+
+    `excluding_user_id` only drops direct grants; a user still reachable via a
+    permission group is correctly counted, mirroring what `user_remove` mutates.
+    """
+    ids: set[int] = set()
+    for perm in zpod.permissions:
+        if perm.permission not in _MAINTAINER_LEVELS:
+            continue
+        for user in perm.users:
+            if user.id != excluding_user_id:
+                ids.add(user.id)
+        for group in perm.permission_groups:
+            if group.id == excluding_group_id:
+                continue
+            ids.update(member.id for member in group.users)
+    return ids
+
 
 class ZpodPermissionService(ServiceBase):
     base_model: SQLModel = M.ZpodComponent
@@ -51,15 +80,24 @@ class ZpodPermissionService(ServiceBase):
         if perm := next(
             (x for x in zpod.permissions if x.permission == permission), None
         ):
-            for perm_user in perm.users:
-                if perm_user.id == user.id:
-                    perm.users.remove(perm_user)
-                    break
-            else:
+            if not any(perm_user.id == user.id for perm_user in perm.users):
                 raise HTTPException(
                     status_code=status.HTTP_406_NOT_ACCEPTABLE,
                     detail=f"User not found in permission: {permission}",
                 )
+            # Refuse to orphan the zPod: a removal must leave at least one
+            # owner/admin principal behind.
+            if permission in _MAINTAINER_LEVELS and not _remaining_maintainer_user_ids(
+                zpod, excluding_user_id=user.id
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="Cannot remove the last owner/admin of a zPod",
+                )
+            for perm_user in perm.users:
+                if perm_user.id == user.id:
+                    perm.users.remove(perm_user)
+                    break
             if not perm.users and not perm.permission_groups:
                 self.session.delete(perm)
             self.session.commit()
@@ -106,15 +144,26 @@ class ZpodPermissionService(ServiceBase):
         if perm := next(
             (x for x in zpod.permissions if x.permission == permission), None
         ):
-            for perm_group in perm.permission_groups:
-                if perm_group.id == group.id:
-                    perm.permission_groups.remove(perm_group)
-                    break
-            else:
+            if not any(
+                perm_group.id == group.id for perm_group in perm.permission_groups
+            ):
                 raise HTTPException(
                     status_code=status.HTTP_406_NOT_ACCEPTABLE,
                     detail=f"Group not found in permission: {permission}",
                 )
+            # Refuse to orphan the zPod: a removal must leave at least one
+            # owner/admin principal behind.
+            if permission in _MAINTAINER_LEVELS and not _remaining_maintainer_user_ids(
+                zpod, excluding_group_id=group.id
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="Cannot remove the last owner/admin of a zPod",
+                )
+            for perm_group in perm.permission_groups:
+                if perm_group.id == group.id:
+                    perm.permission_groups.remove(perm_group)
+                    break
             if not perm.users and not perm.permission_groups:
                 self.session.delete(perm)
             self.session.commit()


### PR DESCRIPTION
- Gate DELETE /zpods/{id}/components/{cid} with ZpodMaintainer; a USER could previously remove components.
- Require OnlySuperAdmin for POST/DELETE /endpoints/{id}/enet; these were reachable by any user able to see the endpoint.
- Relax GET /zpods/{id}/dns[...] from ZpodMaintainer to ZpodReader so a USER can list hostname/IP records; writes stay ZpodMaintainer.
- Add GET /zpods/{id}/permissions/mine returning the caller's highest effective permission (ADMIN >= OWNER > USER) for client show/hide UX.
- Guard permission removal: reject with 409 any removal that would leave a zPod with no OWNER/ADMIN principal (user or group).