### PR TITLE
improve log system, switch live between INFO/DEBUG behavior with zpod…

### DIFF
--- a/zpodapi/src/zpodapi/endpoints/endpoint_permission__routes.py
+++ b/zpodapi/src/zpodapi/endpoints/endpoint_permission__routes.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, status
 
 from zpodapi.lib.global_dependencies import GlobalDepends
+from zpodapi.lib.route_logger import RouteLogger
 from zpodapi.users.user__schemas import UserView
 from zpodcommon.enums import EndpointPermission
 
@@ -19,6 +20,7 @@ from .endpoint_permission__schemas import (
 router = APIRouter(
     prefix="/endpoints/{id}/permissions",
     tags=["endpoints"],
+    route_class=RouteLogger,
 )
 
 

--- a/zpodapi/src/zpodapi/lib/panel.py
+++ b/zpodapi/src/zpodapi/lib/panel.py
@@ -1,16 +1,20 @@
 import contextlib
 import json
-import logging
 from functools import partial
 
 from rich import print as rprint
 from rich.panel import Panel
 from rich.pretty import Pretty
 
-from zpodapi import settings
+# Long individual string values are abbreviated to keep panels readable.
+MAX_STRING_CHARS = 2048
+# A list body larger than this many raw chars is summarised; smaller responses
+# render in full.
+SUMMARISE_THRESHOLD = 16384
+# When a large list body is summarised, show at most this many elements.
+MAX_LIST_ITEMS = 10
 
-logger = logging.getLogger(__name__)
-MyPretty = partial(Pretty, indent_size=2)
+MyPretty = partial(Pretty, indent_size=2, max_string=MAX_STRING_CHARS)
 
 
 def print_panel(output, title=None):
@@ -22,22 +26,62 @@ def print_panel_obj(obj, title=None):
 
 
 def log_obj(obj, title):
-    # DO NOT log bytes (component upload feature)
-    if isinstance(obj, bytes):
-        return
+    """Rich-print a request/response body panel.
 
-    if settings.RICH_MODE:
-        print_panel_obj(format_obj(obj), title)
+    Call only when DEBUG logging is enabled (RouteLogger gates on
+    debug_enabled()). format_obj() decodes/parses the body, summarises large
+    list bodies, and replaces binary payloads with a placeholder.
+    """
+    print_panel_obj(format_obj(obj), title)
 
-    if logger.isEnabledFor(logging.DEBUG):
-        logger.debug("%s %s", title or "", format_obj(obj))
+
+def _summarize_value(value):
+    """Collapse a nested collection to a one-line size hint."""
+    if isinstance(value, dict):
+        return f"<dict: {len(value)} keys>"
+    if isinstance(value, list):
+        return f"<list: {len(value)} items>"
+    return value
+
+
+def _summarize_item(item):
+    """Reduce one list element to a scannable form.
+
+    Keeps every key (so the shape stays visible) but collapses nested dict/list
+    values to a compact size hint, so a large list body stays readable.
+    """
+    if not isinstance(item, dict):
+        return item
+    return {key: _summarize_value(value) for key, value in item.items()}
 
 
 def format_obj(obj):
+    """Prepare a request/response body for display.
+
+    Bytes are utf-8 decoded (binary -> placeholder) and JSON is parsed so it
+    renders as a pretty tree. Small bodies render in full; a large list body
+    (e.g. GET /zpods, GET /components) is summarised — each element reduced to
+    its scalar fields with nested collections collapsed to a size hint, and
+    only the first MAX_LIST_ITEMS shown, the rest noted as truncated.
+    """
     if isinstance(obj, bytes):
-        obj = obj.decode("utf-8")
+        try:
+            obj = obj.decode("utf-8")
+        except UnicodeDecodeError:
+            return f"<{len(obj)} bytes of binary data>"
+
+    # Only large bodies are summarised; small responses render in full.
+    large = isinstance(obj, str) and len(obj) > SUMMARISE_THRESHOLD
 
     if isinstance(obj, str):
         with contextlib.suppress(json.JSONDecodeError):
             obj = json.loads(obj)
+
+    if large and isinstance(obj, list):
+        items = [_summarize_item(item) for item in obj[:MAX_LIST_ITEMS]]
+        hidden = len(obj) - len(items)
+        if hidden:
+            items.append(f"... [{hidden} elements truncated] ...")
+        return items
+
     return obj

--- a/zpodapi/src/zpodapi/lib/route_logger.py
+++ b/zpodapi/src/zpodapi/lib/route_logger.py
@@ -1,10 +1,11 @@
-from typing import Callable
+from collections.abc import Callable
 
 from fastapi import HTTPException, Request, Response
 from fastapi.exceptions import RequestValidationError
 from fastapi.routing import APIRoute
 
 from zpodapi.lib.panel import log_obj
+from zpodcommon.lib.debug_level import debug_enabled
 
 
 class RouteLogger(APIRoute):
@@ -12,14 +13,21 @@ class RouteLogger(APIRoute):
         original_route_handler = super().get_route_handler()
 
         async def custom_route_handler(request: Request) -> Response:
+            # At INFO level skip the dump entirely (the uvicorn access log is
+            # the INFO baseline) — and avoid reading the request body at all.
+            if not debug_enabled():
+                return await original_route_handler(request)
+
             mp = f"{request.method.upper()} {request.url.path}"
             if request.url.query:
                 mp += f"?{request.url.query}"
 
-            log_obj(await request.body(), f"REQUEST {mp}")
+            if body := await request.body():
+                log_obj(body, f"REQUEST {mp}")
             try:
                 response: Response = await original_route_handler(request)
-                log_obj(response.body, f"RESPONSE {mp}")
+                if response.body:
+                    log_obj(response.body, f"RESPONSE {mp}")
                 return response
             except RequestValidationError as exc:
                 log_obj({"detail": exc.errors()}, f"RESPONSE {mp}")

--- a/zpodapi/src/zpodapi/permission_groups/permission_group__routes.py
+++ b/zpodapi/src/zpodapi/permission_groups/permission_group__routes.py
@@ -1,17 +1,21 @@
 from fastapi import APIRouter, HTTPException, status
 
 from zpodapi.lib.global_dependencies import GlobalDepends
+from zpodapi.lib.route_logger import RouteLogger
 
 from ..users.user__schemas import UserView
 from .permission_group__dependencies import PermissionGroupAnnotations
-from .permission_group__schemas import (PermissionGroupCreate,
-                                        PermissionGroupUpdate,
-                                        PermissionGroupUserAdd,
-                                        PermissionGroupView)
+from .permission_group__schemas import (
+    PermissionGroupCreate,
+    PermissionGroupUpdate,
+    PermissionGroupUserAdd,
+    PermissionGroupView,
+)
 
 router = APIRouter(
     prefix="/permission_groups",
     tags=["permission_groups"],
+    route_class=RouteLogger,
 )
 
 

--- a/zpodapi/src/zpodapi/zpods/zpod__services.py
+++ b/zpodapi/src/zpodapi/zpods/zpod__services.py
@@ -195,7 +195,6 @@ class ZpodService(ServiceBase):
                 M.Profile.name == profile_name.lower(),
             )
         ).one_or_none():
-            print(profile)
             validate_profile(session=self.session, profile_obj=profile.profile)
         else:
             raise HTTPException(

--- a/zpodapi/src/zpodapi/zpods/zpod_component__routes.py
+++ b/zpodapi/src/zpodapi/zpods/zpod_component__routes.py
@@ -1,5 +1,7 @@
 from fastapi import APIRouter, status
 
+from zpodapi.lib.route_logger import RouteLogger
+
 from .zpod__dependencies import ZpodAnnotations, ZpodDepends
 from .zpod_component__dependencies import ZpodComponentAnnotations
 from .zpod_component__schemas import ZpodComponentCreate, ZpodComponentView
@@ -7,6 +9,7 @@ from .zpod_component__schemas import ZpodComponentCreate, ZpodComponentView
 router = APIRouter(
     prefix="/zpods/{id}/components",
     tags=["zpods"],
+    route_class=RouteLogger,
 )
 
 

--- a/zpodapi/src/zpodapi/zpods/zpod_dns__routes.py
+++ b/zpodapi/src/zpodapi/zpods/zpod_dns__routes.py
@@ -1,5 +1,7 @@
 from fastapi import APIRouter, HTTPException, status
 
+from zpodapi.lib.route_logger import RouteLogger
+
 from .zpod__dependencies import ZpodAnnotations, ZpodDepends
 from .zpod_dns__dependencies import ZpodDnsAnnotations
 from .zpod_dns__schemas import ZpodDnsCreate, ZpodDnsUpdate, ZpodDnsView
@@ -7,6 +9,7 @@ from .zpod_dns__schemas import ZpodDnsCreate, ZpodDnsUpdate, ZpodDnsView
 router = APIRouter(
     prefix="/zpods/{id}/dns",
     tags=["zpods"],
+    route_class=RouteLogger,
 )
 
 

--- a/zpodapi/src/zpodapi/zpods/zpod_network__routes.py
+++ b/zpodapi/src/zpodapi/zpods/zpod_network__routes.py
@@ -1,11 +1,14 @@
 from fastapi import APIRouter
 
+from zpodapi.lib.route_logger import RouteLogger
+
 from .zpod__dependencies import ZpodAnnotations
 from .zpod_network__schemas import ZpodNetworkView
 
 router = APIRouter(
     prefix="/zpods/{id}/networks",
     tags=["zpods"],
+    route_class=RouteLogger,
 )
 
 

--- a/zpodapi/src/zpodapi/zpods/zpod_permission__routes.py
+++ b/zpodapi/src/zpodapi/zpods/zpod_permission__routes.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, HTTPException, status
 
+from zpodapi.lib.route_logger import RouteLogger
 from zpodapi.users.user__schemas import UserView
 from zpodcommon.enums import ZpodPermission
 
@@ -19,6 +20,7 @@ from .zpod_permission__schemas import (
 router = APIRouter(
     prefix="/zpods/{id}/permissions",
     tags=["zpods"],
+    route_class=RouteLogger,
 )
 
 

--- a/zpodcommon/src/zpodcommon/lib/debug_level.py
+++ b/zpodcommon/src/zpodcommon/lib/debug_level.py
@@ -1,0 +1,32 @@
+"""Cached lookup of the zpodfactory_debug_level setting.
+
+Avoids a DB round-trip on every request: the value is re-read at most once per
+TTL window, so toggling the setting in the DB takes effect within ~TTL seconds
+with no container restart.
+"""
+
+import time
+
+# The setting is re-read from the DB at most once per this many seconds.
+_TTL_SECONDS = 10.0
+
+_cache = {"debug": False, "checked_at": 0.0}
+
+
+def debug_enabled() -> bool:
+    """True when zpodfactory_debug_level is set to DEBUG.
+
+    TTL-cached (~10s). On any error (DB unreachable, missing value) the last
+    known-good result is kept, defaulting to False (INFO).
+    """
+    now = time.monotonic()
+    if now - _cache["checked_at"] >= _TTL_SECONDS:
+        _cache["checked_at"] = now
+        try:
+            from zpodcommon.lib.dbutils import DBUtils
+
+            value = DBUtils.get_setting_value("zpodfactory_debug_level")
+            _cache["debug"] = (value or "INFO").strip().upper() == "DEBUG"
+        except Exception:
+            pass  # keep last known-good
+    return _cache["debug"]

--- a/zpodcommon/src/zpodcommon/lib/nsx.py
+++ b/zpodcommon/src/zpodcommon/lib/nsx.py
@@ -45,12 +45,11 @@ def event_hook_response(response: httpx.Response):
     response.results = types.MethodType(results, response)
 
     response.read()
-    request = response.request
 
     # Log Response
     print(
-        f"RESPONSE: {request.method.upper()} {request.url}\n"
-        f"{response.status_code} {response.safejson() or response.text}"
+        f"RESPONSE: {response.status_code}\n"
+        f"{response.text}"
     )
 
 

--- a/zpodcommon/src/zpodcommon/lib/zboxapi.py
+++ b/zpodcommon/src/zpodcommon/lib/zboxapi.py
@@ -44,11 +44,7 @@ def safejson_fastapi(response: httpx.Response):
 
 
 def event_hook_request(request: httpx.Request):
-    # Log Request
-    print(
-        f"REQUEST: {request.method.upper()} {request.url}\n"
-        f"{request.content.decode()}"
-    )
+    pass
 
 
 def event_hook_response(response: httpx.Response):
@@ -59,13 +55,6 @@ def event_hook_response(response: httpx.Response):
     )
 
     response.read()
-    request = response.request
-
-    # Log Response
-    print(
-        f"RESPONSE: {request.method.upper()} {request.url}\n"
-        f"{response.status_code} {response.safejson() or response.text}"
-    )
 
 
 class ZboxApiClient(httpx.Client):

--- a/zpodengine/src/zpodengine/lib/ovfdeployer.py
+++ b/zpodengine/src/zpodengine/lib/ovfdeployer.py
@@ -103,7 +103,7 @@ def ovf_deployer(zpod_component: M.ZpodComponent):
     )
 
     print("govc ovf property options generated file")
-    print(govc_spec_render)
+    print(json.dumps(json.loads(govc_spec_render), indent=2))
 
     options_filename = f"/tmp/{zpod_component.fqdn}.json"
     with open(options_filename, "w") as f:

--- a/zpodengine/src/zpodengine/lib/vcsadeployer.py
+++ b/zpodengine/src/zpodengine/lib/vcsadeployer.py
@@ -105,7 +105,7 @@ def vcsa_deployer(zpod_component: M.ZpodComponent):
     )
 
     print("vcsa spec options generated file")
-    print(vcsa_spec_render)
+    print(json.dumps(json.loads(vcsa_spec_render), indent=2))
 
     vm_name = f"vcsa.{zpod.domain}"
 


### PR DESCRIPTION
…factory_debug_level

The zpodfactory_debug_level setting now drives logging verbosity live: set it to DEBUG (or back to INFO) and the change applies within ~10s, with no container restart.

- Add zpodcommon/lib/debug_level.py — debug_enabled(), a TTL-cached (10s) read of the zpodfactory_debug_level setting.
- zpodapi: RouteLogger now covers all 15 routers. At INFO only the uvicorn access log shows; at DEBUG every route also dumps its request and response payloads as rich panels — bodies decoded, JSON pretty-printed, large list responses summarised, binary payloads and long strings abbreviated.
- Tidy surrounding logs: pretty-print the OVF/VCSA deploy spec JSON, and drop noisy unconditional prints from the zbox/NSX clients and the zpod service layer.