### PR TITLE
Improve reliability on vSphere and NSX calls + better logging

### DIFF
--- a/zpodcommon/src/zpodcommon/lib/nsx.py
+++ b/zpodcommon/src/zpodcommon/lib/nsx.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import time
 import types
 from functools import cache, cached_property
 
@@ -9,6 +10,88 @@ from zpodcommon import models as M
 from zpodcommon.lib import database
 
 logger = logging.getLogger(__name__)
+
+
+# HTTP statuses we treat as transient — typically what a saturated reverse
+# proxy in front of NSX (or NSX while it's hammering vCenter) returns when
+# it can't service the request right now.
+RETRY_STATUS_CODES = frozenset({502, 503, 504})
+
+# httpx exceptions that signal a transient network/protocol failure where
+# another attempt has a real chance of succeeding. ConnectError /
+# ConnectTimeout are already retried by httpx.HTTPTransport via its own
+# `retries=` parameter, but we list them here too so the application-level
+# loop catches any that escape (e.g. on the read side).
+RETRY_HTTPX_EXCEPTIONS = (
+    httpx.ConnectError,
+    httpx.ConnectTimeout,
+    httpx.ReadError,
+    httpx.ReadTimeout,
+    httpx.RemoteProtocolError,
+)
+
+
+class RetryTransport(httpx.HTTPTransport):
+    """``httpx.HTTPTransport`` that retries transient failures.
+
+    The NSX manager sits behind a reverse proxy that occasionally returns
+    ``502/503/504`` or an empty body when NSX or vCenter are under load.
+    Connection-establishment retries are delegated to the parent class
+    (``retries=`` parameter); on top of that this transport adds:
+
+      * status-code retries for :data:`RETRY_STATUS_CODES`
+      * exception retries for :data:`RETRY_HTTPX_EXCEPTIONS`
+      * exponential backoff between attempts (``backoff * 2**attempt``)
+
+    Applied to every NSX request — including the auth POST — so callers
+    don't need their own retry decorators.
+    """
+
+    def __init__(
+        self,
+        *args,
+        max_retries: int = 3,
+        backoff: float = 0.5,
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, retries=max_retries, **kwargs)
+        self._max_retries = max_retries
+        self._backoff = backoff
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        for attempt in range(self._max_retries + 1):
+            try:
+                response = super().handle_request(request)
+            except RETRY_HTTPX_EXCEPTIONS as exc:
+                if attempt >= self._max_retries:
+                    raise
+                # print() rather than logger.warning so Prefect's
+                # log_prints=True picks it up into the task-run logs.
+                print(
+                    f"NSX {request.method} {request.url} — "
+                    f"{type(exc).__name__} "
+                    f"(attempt {attempt + 1}/{self._max_retries + 1}), "
+                    "retrying"
+                )
+                time.sleep(self._backoff * (2 ** attempt))
+                continue
+            if (
+                response.status_code in RETRY_STATUS_CODES
+                and attempt < self._max_retries
+            ):
+                print(
+                    f"NSX {request.method} {request.url} — "
+                    f"HTTP {response.status_code} "
+                    f"(attempt {attempt + 1}/{self._max_retries + 1}), "
+                    "retrying"
+                )
+                response.close()
+                time.sleep(self._backoff * (2 ** attempt))
+                continue
+            return response
+        # Loop body returns or raises on every path; this is just a safety
+        # belt to satisfy static type checkers.
+        raise RuntimeError("RetryTransport loop exited without returning")
 
 
 def safejson(response: httpx.Response):
@@ -23,6 +106,18 @@ def safejson(response: httpx.Response):
     try:
         return response.json()
     except json.JSONDecodeError:
+        # A 2xx (typically 200) with a body that isn't valid JSON usually
+        # means the NSX reverse proxy returned an HTML / empty page under
+        # load. Swallow it as {} for backward compat, but log the status
+        # code and a body snippet so the case is visible in Prefect logs
+        # (log_prints=True captures print()) — if this fires regularly,
+        # the next step is to retry it.
+        body_preview = (response.text or "<empty body>")[:200]
+        print(
+            f"NSX safejson: {response.request.method} {response.request.url} "
+            f"returned HTTP {response.status_code} with non-JSON body, "
+            f"falling back to {{}} — body[:200]={body_preview!r}"
+        )
         return {}
 
 
@@ -81,9 +176,31 @@ class Auth(httpx.Auth):
         logger.debug(
             f"POST {self.auth_args.get('url')} - {self.auth_args.get('headers')}"
         )
-        response = httpx.post(**self.auth_args)
+        # Drive the auth POST through a Client backed by RetryTransport so
+        # the login itself rides through transient 5xx / read errors from
+        # the NSX reverse proxy — the original symptom this fix targets.
+        post_args = {k: v for k, v in self.auth_args.items() if k != "verify"}
+        verify = self.auth_args.get("verify", True)
+        with httpx.Client(transport=RetryTransport(verify=verify)) as client:
+            response = client.post(**post_args)
+        # Surface the auth status code unconditionally — at the same level
+        # as the "Initializing NSX connection" message that ran earlier in
+        # NsxClient.__init__ — so operators can see exactly what HTTP
+        # status NSX returned before any downstream call uses the token.
+        # This is the symptom from the original JSONDecodeError traceback,
+        # where the actual status was hidden by response.json() crashing.
+        print(
+            f"NSX auth POST {post_args.get('url')} -> "
+            f"HTTP {response.status_code}"
+        )
         if response.status_code != 200:
-            raise ValueError(response.json())
+            # Use .text not .json(): a saturated reverse proxy returns an
+            # HTML / empty body and json() would mask the real auth failure
+            # with a JSONDecodeError.
+            raise ValueError(
+                f"NSX auth failed (HTTP {response.status_code}): "
+                f"{response.text or '<empty body>'}"
+            )
         return response.headers.get(self.token_name), response.cookies
 
     def update_request(self, request: httpx.Request):
@@ -104,6 +221,10 @@ class NsxClient(httpx.Client):
         kwargs.setdefault("event_hooks", {})
         kwargs["event_hooks"].setdefault("request", []).insert(0, event_hook_request)
         kwargs["event_hooks"].setdefault("response", []).insert(0, event_hook_response)
+        # Every NSX request runs through RetryTransport so transient
+        # 502/503/504 from the reverse proxy and read-side errors get
+        # retried transparently to callers.
+        kwargs.setdefault("transport", RetryTransport(verify=verify))
 
         nsx_url = f"https://{host}"
         print(f"Initializing NSX connection {nsx_url} with user {user}")

--- a/zpodcommon/src/zpodcommon/lib/vmware.py
+++ b/zpodcommon/src/zpodcommon/lib/vmware.py
@@ -67,19 +67,54 @@ class vCenter:
                 ret.extend(arg)
         return ret
 
-    def get_obj(self, vimtype, attr, value, root=None, props=None):
-        objs = self.get_obj_list(vimtype, root=root)
-        info = [
-            oprops if props else oprops["obj"]
-            for oprops in self.get_props(data=objs, props=self.joinitems(attr, props))
-            if oprops[attr] == value
-        ]
-        li = len(info)
-        if li == 1:
-            return info[0]
-        elif li == 0:
-            return None
-        raise Exception("Multiple results found when there should only be one")
+    def get_obj(
+        self,
+        vimtype,
+        attr,
+        value,
+        root=None,
+        props=None,
+        max_retries: int = 3,
+        backoff: float = 1.0,
+    ):
+        # vSphere container views hand out managed-object references that
+        # can go stale if another caller (e.g. a parallel zpod_destroy)
+        # deletes objects concurrently. RetrievePropertiesEx then raises
+        # vmodl.fault.ManagedObjectNotFound and fails the whole batch,
+        # even when our target object is fine. Re-enumerating yields a
+        # fresh view that excludes the deleted ref; retry with backoff.
+        for attempt in range(max_retries + 1):
+            try:
+                objs = self.get_obj_list(vimtype, root=root)
+                info = [
+                    oprops if props else oprops["obj"]
+                    for oprops in self.get_props(
+                        data=objs, props=self.joinitems(attr, props)
+                    )
+                    if oprops[attr] == value
+                ]
+                li = len(info)
+                if li == 1:
+                    return info[0]
+                elif li == 0:
+                    return None
+                raise Exception(
+                    "Multiple results found when there should only be one"
+                )
+            except vmodl.fault.ManagedObjectNotFound as exc:
+                if attempt >= max_retries:
+                    raise
+                # print() rather than logger.warning so Prefect's
+                # log_prints=True picks it up into the task-run logs.
+                print(
+                    f"vSphere ManagedObjectNotFound looking up "
+                    f"{vimtype.__name__} '{value}' (stale ref {exc.obj}, "
+                    f"attempt {attempt + 1}/{max_retries + 1}) — "
+                    "re-enumerating"
+                )
+                time.sleep(backoff * (2 ** attempt))
+        # Loop returns or raises on every path; safety belt for type checkers.
+        raise RuntimeError("get_obj retry loop exited without returning")
 
     def get_obj_list(self, vimtype, root=None, props=None):
         if root is None:
@@ -93,7 +128,7 @@ class vCenter:
         return self.get_props(data=view, props=props) if props else view
 
     def get_portgroups(self, props=None):
-        return self.get_obj_list([vim.Network], props=props)
+        return self.get_obj_list(vim.Network, props=props)
 
     def get_portgroup(self, name, props=None):
         return self.get_obj(vim.Network, "name", name, props=props)
@@ -189,16 +224,32 @@ class vCenter:
 
         resource_pool.CreateVApp(vapp_name, resSpec, configSpec, vmFolderMO)
 
-    def delete_vapp(self, vapp_name):
-        if vapp := self.get_vapp(vapp_name):
-            if vapp.summary.vAppState != "stopped":
-                # Wait for vApp PowerOff operation to complete
-                task_id = vapp.PowerOffVApp_Task(True)
-                task.WaitForTask(task_id)
+    def delete_vapp(self, vapp_name, max_retries: int = 5, backoff: float = 2.0):
+        # vCenter serializes operations on a vApp. If a deploy/clone/power-on
+        # task is still settling when we tear the zpod down, PowerOff/Destroy
+        # raise vim.fault.VAppTaskInProgress ("Operation cannot be performed
+        # while a vApp operation is in progress."). Re-fetch and retry with
+        # backoff until the in-flight task clears.
+        for attempt in range(max_retries + 1):
+            try:
+                if vapp := self.get_vapp(vapp_name):
+                    if vapp.summary.vAppState != "stopped":
+                        # Wait for vApp PowerOff operation to complete
+                        task.WaitForTask(vapp.PowerOffVApp_Task(True))
 
-            # Wait for vApp Destroy operation to complete
-            task_id = vapp.Destroy_Task()
-            task.WaitForTask(task_id)
+                    # Wait for vApp Destroy operation to complete
+                    task.WaitForTask(vapp.Destroy_Task())
+                return
+            except vim.fault.VAppTaskInProgress:
+                if attempt >= max_retries:
+                    raise
+                # print() rather than logger.warning so Prefect's
+                # log_prints=True picks it up into the task-run logs.
+                print(
+                    f"vSphere VAppTaskInProgress deleting vApp '{vapp_name}' "
+                    f"(attempt {attempt + 1}/{max_retries + 1}) — retrying"
+                )
+                time.sleep(backoff * (2 ** attempt))
 
     def delete_vm_from_vapp(self, vapp_name: str, vm_name: str):
         print("Delete VM from vApp")


### PR DESCRIPTION
Add automatic retries on transient failures when the engine talks to NSX and vCenter during deploy/destroy, plus logging so any issue is diagnosable from Prefect task logs (print() is captured by log_prints=True) instead of a masked stack trace.

NSX client (zpodcommon/lib/nsx.py):
- New RetryTransport (httpx.HTTPTransport) applied to every NSX request, including the auth POST: retries HTTP 502/503/504 and transient httpx errors (ConnectError/ConnectTimeout/ReadError/ReadTimeout/ RemoteProtocolError) with exponential backoff (0.5 * 2**attempt, 3 retries); connection-establishment retries delegated to httpx.
- Auth hardening: login retries transient failures and raises using response.text instead of .json(), so a non-JSON/empty body no longer masks the real failure with a JSONDecodeError; auth status is logged.
- safejson(): a 2xx with a non-JSON body still falls back to {} but now logs the status and a body snippet so the case is visible.

vCenter client (zpodcommon/lib/vmware.py):
- get_obj() retries vmodl.fault.ManagedObjectNotFound (stale container- view MoRefs from a parallel zpod_destroy) by re-enumerating, with backoff (3 retries).
- delete_vapp() retries vim.fault.VAppTaskInProgress (vApp teardown racing a still-settling deploy/clone/power-on task) by re-fetching and retrying power-off/destroy, with backoff (5 retries).
- get_portgroups() fix: it passed [vim.Network] to get_obj_list, which wraps the type again and raised 'expected type type, but got list'; pass the bare type (unbreaks the superadmin endpoint-verify check).