### PR TITLE
Add ff_endpoint_ova_staging: stage L1 OVAs as templates, clone per de…

### DIFF
--- a/zpodcommon/src/zpodcommon/lib/vmware.py
+++ b/zpodcommon/src/zpodcommon/lib/vmware.py
@@ -166,6 +166,231 @@ class vCenter:
                 if result := self.find_folder(name, child):
                     return result
 
+    def get_folder(self, name, root=None):
+        """Find a VM folder by name anywhere under `root` (default: the whole
+        inventory)."""
+        content = self.si.content
+        folders = content.viewManager.CreateContainerView(
+            root or content.rootFolder, [vim.Folder], True
+        ).view
+        for folder in folders:
+            if result := self.find_folder(name, folder):
+                return result
+        return None
+
+    def get_or_create_folder(self, parent_name, child_name):
+        """Return the `child_name` subfolder of `parent_name`, creating it if
+        missing."""
+        parent = self.get_folder(parent_name)
+        if parent is None:
+            raise RuntimeError(f"folder not found: {parent_name}")
+        for child in parent.childEntity:
+            if isinstance(child, vim.Folder) and child.name == child_name:
+                return child
+        return parent.CreateFolder(child_name)
+
+    @staticmethod
+    def inventory_path(obj):
+        """Absolute vCenter inventory path of a managed object, e.g.
+        /<datacenter>/vm/<folder>/<sub> (the rootFolder, whose parent is None,
+        renders as the leading slash)."""
+        parts = []
+        node = obj
+        while node is not None and node.parent is not None:
+            parts.append(node.name)
+            node = node.parent
+        return "/" + "/".join(reversed(parts))
+
+    def get_network(self, name=None, preferred="VM Network"):
+        """Return the network named `name`; if `name` is None, return any
+        network on the endpoint, preferring `preferred`."""
+        if name is not None:
+            return self.get_portgroup(name)
+        networks = self.get_obj_list(vim.Network)
+        if not networks:
+            return None
+        for net in networks:
+            if net.name == preferred:
+                return net
+        return networks[0]
+
+    def mark_as_template(self, vm):
+        vm.MarkAsTemplate()
+
+    def set_custom_field(self, entity, name, value):
+        cfm = self.si.content.customFieldsManager
+        key = next((f.key for f in cfm.field or [] if f.name == name), None)
+        if key is None:
+            key = cfm.AddFieldDefinition(name=name, moType=vim.VirtualMachine).key
+        cfm.SetField(entity=entity, key=key, value=value)
+
+    def get_custom_field(self, entity, name):
+        cfm = self.si.content.customFieldsManager
+        key = next((f.key for f in cfm.field or [] if f.name == name), None)
+        if key is None:
+            return None
+        return next(
+            (cv.value for cv in entity.customValue or [] if cv.key == key), None
+        )
+
+    def network_backing(self, network):
+        """Build a NIC backing matching the network type (NSX opaque / DVPG /
+        standard)."""
+        if isinstance(network, vim.OpaqueNetwork):
+            backing = vim.vm.device.VirtualEthernetCard.OpaqueNetworkBackingInfo()
+            backing.opaqueNetworkId = network.summary.opaqueNetworkId
+            backing.opaqueNetworkType = network.summary.opaqueNetworkType
+            return backing
+        if isinstance(network, vim.dvs.DistributedVirtualPortgroup):
+            backing = (
+                vim.vm.device.VirtualEthernetCard.DistributedVirtualPortBackingInfo()
+            )
+            backing.port = vim.dvs.PortConnection()
+            backing.port.portgroupKey = network.key
+            backing.port.switchUuid = network.config.distributedVirtualSwitch.uuid
+            return backing
+        backing = vim.vm.device.VirtualEthernetCard.NetworkBackingInfo()
+        backing.deviceName = network.name
+        backing.network = network
+        return backing
+
+    def clone_template(
+        self,
+        *,
+        template,
+        name,
+        resource_pool_name,
+        datastore_name,
+        folder_name,
+        vapp_properties=None,
+        portgroup_name=None,
+        power_on=False,
+    ):
+        """Clone a VM template into the given resource pool / datastore / folder.
+
+        Optionally override vApp/OVF property values (``{key: value}`` matched by
+        fully-qualified OVF key) and remap *all* NICs to ``portgroup_name``.
+        Returns the cloned VM, left powered off unless ``power_on`` is set.
+        """
+        pool = self.get_vapp(resource_pool_name) or self.get_obj(
+            vim.ResourcePool, "name", resource_pool_name
+        )
+        if pool is None:
+            raise RuntimeError(f"resource pool/vApp not found: {resource_pool_name}")
+        datastore = self.get_obj(vim.Datastore, "name", datastore_name)
+        if datastore is None:
+            raise RuntimeError(f"datastore not found: {datastore_name}")
+        folder = self.get_folder(folder_name)
+        if folder is None:
+            raise RuntimeError(f"vmfolder not found: {folder_name}")
+
+        relocate = vim.vm.RelocateSpec()
+        relocate.pool = pool  # VirtualApp is a ResourcePool; clone lands in it
+        relocate.datastore = datastore
+
+        config = vim.vm.ConfigSpec()
+        if vapp_properties:
+            config.vAppConfig = self.vapp_property_overrides(
+                template, vapp_properties
+            )
+        if portgroup_name:
+            config.deviceChange = self.nic_portgroup_changes(template, portgroup_name)
+
+        clone_spec = vim.vm.CloneSpec(
+            location=relocate, config=config, powerOn=power_on, template=False
+        )
+        task.WaitForTask(
+            template.CloneVM_Task(folder=folder, name=name, spec=clone_spec)
+        )
+        return self.get_vm(name)
+
+    def vapp_property_overrides(self, template, values):
+        """``VmConfigSpec`` overriding the cloned VM's vApp/OVF property values.
+
+        govc/OVF keys are fully qualified (``[classId.]id[.instanceId]``, e.g.
+        ``vami.ip0.SDDC-Manager``) while vCenter splits them into
+        id/classId/instanceId, so match every key form. Each set/miss is logged
+        for troubleshooting (secrets masked)."""
+        spec = vim.vApp.VmConfigSpec()
+        vapp = template.config.vAppConfig
+        template_props = list(vapp.property) if vapp else []
+
+        by_key = {}
+        for prop in template_props:
+            for form in self.property_key_forms(prop):
+                by_key.setdefault(form, prop)
+
+        print(
+            f"Injecting {len(values)} OVF properties "
+            f"({len(template_props)} available on template)"
+        )
+        props = []
+        unmatched = []
+        for key, value in values.items():
+            prop = by_key.get(key)
+            if prop is None:
+                unmatched.append(key)
+                print(f"  MISS {key!r} ({self.mask_secret(key, value)}) — no template property")
+                continue
+            info = vim.vApp.PropertyInfo()
+            info.key = prop.key
+            info.value = value
+            pspec = vim.vApp.PropertySpec()
+            pspec.operation = "edit"
+            pspec.info = info
+            props.append(pspec)
+            print(
+                f"  SET {key!r} -> id={prop.id!r} instanceId={prop.instanceId!r} "
+                f"key={prop.key} = {self.mask_secret(key, value)}"
+            )
+        if unmatched:
+            print(f"  WARNING: {len(unmatched)} unmatched: {unmatched}")
+        spec.property = props
+        return spec
+
+    def nic_portgroup_changes(self, template, portgroup_name):
+        """Device changes remapping ALL NICs of `template` to `portgroup_name`."""
+        network = self.get_portgroup(portgroup_name)
+        if network is None:
+            raise RuntimeError(f"portgroup not found: {portgroup_name}")
+        backing = self.network_backing(network)
+        changes = []
+        for device in template.config.hardware.device:
+            if isinstance(device, vim.vm.device.VirtualEthernetCard):
+                device.backing = backing
+                spec = vim.vm.device.VirtualDeviceSpec()
+                spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.edit
+                spec.device = device
+                changes.append(spec)
+        print(
+            f"Remapping {len(changes)} NIC(s) to portgroup {portgroup_name!r} "
+            f"({type(backing).__name__})"
+        )
+        return changes
+
+    @staticmethod
+    def property_key_forms(prop):
+        """All fully-qualified spellings govc may use for a vApp property:
+        id, classId.id, id.instanceId, classId.id.instanceId."""
+        cid = prop.classId or ""
+        iid = prop.instanceId or ""
+        forms = [prop.id]
+        if cid:
+            forms.append(f"{cid}.{prop.id}")
+        if iid:
+            forms.append(f"{prop.id}.{iid}")
+        if cid and iid:
+            forms.append(f"{cid}.{prop.id}.{iid}")
+        return forms
+
+    @staticmethod
+    def mask_secret(key, value):
+        """Hide secret values in logs (Prefect persists task logs)."""
+        k = key.lower()
+        if "password" in k or "passwd" in k or "ssh" in k:
+            return f"***(len={len(str(value))})"
+        return repr(value)
+
     def get_vapps(self, root=None, props=None):
         return self.get_obj_list(vim.VirtualApp, root=root, props=props)
 
@@ -204,16 +429,7 @@ class vCenter:
                 else:
                     resource_pool = _resource_pool
 
-        folders = content.viewManager.CreateContainerView(
-            content.rootFolder, [vim.Folder], True
-        ).view
-        vmFolderMO = None
-
-        for folder in folders:
-            if isinstance(folder, vim.Folder):
-                if result := self.find_folder(folder_name, folder):
-                    vmFolderMO = result
-                    break
+        vmFolderMO = self.get_folder(folder_name)
 
         resSpec = vim.ResourceConfigSpec()
         resSpec.memoryAllocation = self.create_allocation_object(resSpec, 163840)
@@ -345,7 +561,7 @@ class vCenter:
         task_id = vm.ReconfigVM_Task(spec)
         task.WaitForTask(task_id)
 
-    def _clone_dvpg_backing_from(self, nic: vim.vm.device.VirtualEthernetCard):
+    def clone_dvpg_backing_from(self, nic: vim.vm.device.VirtualEthernetCard):
         """
         Build a new DVPortgroup backing that matches the given NIC's DVPG.
         Raises if the NIC is not DVPG-backed.
@@ -391,7 +607,7 @@ class vCenter:
             raise ValueError("Cannot infer DVPortgroup: VM has no existing NICs.")
 
         # Mirror the first NIC's DVPG
-        dvpg_backing = self._clone_dvpg_backing_from(current_nics[0])
+        dvpg_backing = self.clone_dvpg_backing_from(current_nics[0])
 
         to_add = vnic_num - current_count
 

--- a/zpodengine/src/zpodengine/lib/ova_staging.py
+++ b/zpodengine/src/zpodengine/lib/ova_staging.py
@@ -1,0 +1,233 @@
+"""OVA staging orchestration for ``ff_endpoint_ova_staging``.
+
+Instead of uploading an OVA from the zPodFactory host to the endpoint vCenter on
+every zPod deployment (network/resource intensive), upload it once into a
+``components-staging`` folder, switch it into a VM Template, and clone that
+template for every subsequent deployment, injecting the per-zPod OVF properties
+and portgroup at clone time.
+
+This module is pure orchestration — the govc upload, the atomic DB claim and the
+spec rendering. All vCenter/pyVmomi operations live on
+``zpodcommon.lib.vmware.vCenter`` (``get_or_create_folder``, ``clone_template``,
+``get/set_custom_field``, ``get_network``, ``inventory_path``, ``delete_vm``…).
+
+Only used for L1 components (``component_isnested is False``). The template is
+NEVER powered on (powering it on would consume the one-shot OVF customization
+and break every later clone). Everything here is best-effort and idempotent: the
+caller falls back to a plain ``govc import.ova`` if anything raises.
+"""
+
+import json
+import time
+
+from jinja2 import Template
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import select
+
+from zpodcommon import models as M
+from zpodcommon.lib.vmware import vCenter
+from zpodengine.lib import database
+from zpodengine.lib.commands import cmd_execute
+
+STAGING_FOLDER = "components-staging"
+STATUS_FIELD = "zpodfactory_staging_status"
+STATUS_READY = "staged"
+LOCK_PREFIX = "_ova_staging_lock_"
+
+# A staging upload can be slow (multi-GB OVA). Waiters poll this long for the
+# elected stager to finish before giving up (the caller then falls back to a
+# direct import).
+POLL_SECONDS = 15
+MAX_WAIT_SECONDS = 60 * 60
+
+
+def deploy_from_template(
+    *,
+    zpod: M.Zpod,
+    component: M.Component,
+    compute: dict,
+    govc_spec: dict,
+    real_property_values: dict,
+    vm_name: str,
+    vapp_pool_name: str,
+    portgroup_name: str,
+    govc_url: str,
+):
+    """Ensure a staged template exists for ``component`` then clone it to
+    ``vm_name`` (powered off) with the per-zPod OVF properties and portgroup.
+
+    Raises on any failure so the caller can fall back to a direct OVA import.
+    """
+    with vCenter.auth_by_zpod_endpoint(zpod=zpod) as vc:
+        # Idempotent: nothing to do if this VM is already deployed.
+        if vc.get_vm(name=vm_name) is not None:
+            print(f"[ova_staging] {vm_name} already exists, skipping clone")
+            return
+
+        staging_folder = vc.get_or_create_folder(compute["vmfolder"], STAGING_FOLDER)
+
+        template = ensure_staged_template(
+            vc,
+            endpoint_id=zpod.endpoint.id,
+            component=component,
+            staging_folder=staging_folder,
+            compute=compute,
+            govc_spec=govc_spec,
+            govc_url=govc_url,
+        )
+
+        print(f"[ova_staging] cloning {component.component_uid} -> {vm_name}")
+        vc.clone_template(
+            template=template,
+            name=vm_name,
+            resource_pool_name=vapp_pool_name,
+            datastore_name=compute["storage_datastore"],
+            folder_name=compute["vmfolder"],
+            vapp_properties=real_property_values,
+            portgroup_name=portgroup_name,
+        )
+
+
+def ensure_staged_template(
+    vc, *, endpoint_id, component, staging_folder, compute, govc_spec, govc_url
+):
+    """Return the staged VM Template for ``component``, staging it once if
+    needed. Concurrency is handled by an atomic DB claim (one elected stager)
+    plus a ``staged`` custom attribute that waiters poll; a crashed stager is
+    transparently taken over."""
+    uid = component.component_uid
+    waited = 0
+    while True:
+        template = vc.get_vm(name=uid, root=staging_folder)
+        if template is not None and vc.get_custom_field(template, STATUS_FIELD) == STATUS_READY:
+            return template
+
+        if try_claim(endpoint_id, uid):
+            # We are the elected stager for this component_uid.
+            try:
+                template = vc.get_vm(name=uid, root=staging_folder)
+                if (
+                    template is not None
+                    and vc.get_custom_field(template, STATUS_FIELD) == STATUS_READY
+                ):
+                    return template
+                if template is not None:
+                    # Partial/stale import from a previous crashed attempt.
+                    print(f"[ova_staging] removing stale template {uid}")
+                    vc.delete_vm(template)
+
+                print(f"[ova_staging] staging OVA for {uid}")
+                stage_ova(
+                    vc,
+                    component=component,
+                    compute=compute,
+                    staging_folder=staging_folder,
+                    govc_spec=govc_spec,
+                    govc_url=govc_url,
+                )
+                template = vc.get_vm(name=uid, root=staging_folder)
+                if template is None:
+                    raise RuntimeError(f"template {uid} not found after staging")
+                vc.set_custom_field(template, STATUS_FIELD, STATUS_READY)
+                print(f"[ova_staging] {uid} staged")
+                return template
+            finally:
+                release_claim(endpoint_id, uid)
+
+        # Another worker holds the claim (e.g. a sibling esxi in the same
+        # profile). Wait for it to finish, then re-check / take over if it died.
+        if waited >= MAX_WAIT_SECONDS:
+            raise TimeoutError(f"timed out waiting for {uid} to be staged")
+        print(f"[ova_staging] {uid} staging in progress, waiting...")
+        time.sleep(POLL_SECONDS)
+        waited += POLL_SECONDS
+
+
+def stage_ova(vc, *, component, compute, staging_folder, govc_spec, govc_url):
+    """Upload the OVA once into ``components-staging`` as a VM Template.
+
+    Rendered with neutral placeholder values (the template never boots and every
+    property is overridden per-clone) and forced to PowerOn=False so the
+    one-shot OVF customization is preserved for the clones.
+    """
+    network = vc.get_network()
+    if network is None:
+        raise RuntimeError("no network found on endpoint for staging import")
+    options = build_staging_options(govc_spec, network.name)
+    options_filename = f"/tmp/{component.component_uid}.staging.json"
+    with open(options_filename, "w") as f:
+        f.write(json.dumps(options))
+
+    # govc resolves a relative -folder from the datacenter root, so pass the
+    # absolute inventory path (/<dc>/vm/<vmfolder>/components-staging).
+    folder_path = vc.inventory_path(staging_folder)
+    cmd = (
+        "govc import.ova"
+        " -k"
+        f" -name={component.component_uid}"
+        f" -u='{govc_url}'"
+        f" -pool={compute['resource_pool']}/Resources"
+        f" -ds={compute['storage_datastore']}"
+        f" -folder='{folder_path}'"
+        " -json=true"
+        " -hidden=true"
+        f" -options={options_filename}"
+        f" -dc={compute['datacenter']}"
+        f" /products/{component.component_name}/{component.component_version}/{component.filename}"  # noqa: E501 B950
+    )
+    print(f"[ova_staging] {cmd}")
+    cmd_execute(cmd)
+
+
+def build_staging_options(govc_spec: dict, staging_network: str) -> dict:
+    """Render the govc spec with neutral values and force template-safe flags."""
+    neutral = {
+        "zpod_hostname": "staging",
+        "zpod_ipaddress": "",
+        "zpod_netmask": "",
+        "zpod_netprefix": "",
+        "zpod_gateway": "",
+        "zpod_dns": "",
+        "zpod_nfs": "",
+        "zpod_ntp": "",
+        "zpod_domain": "",
+        "zpod_password": "",
+        "zpod_sshkey": "",
+        "zpod_portgroup": staging_network,
+    }
+    options = json.loads(Template(json.dumps(govc_spec)).render(**neutral))
+    options["PowerOn"] = False
+    options["MarkAsTemplate"] = True
+    options["InjectOvfEnv"] = False
+    options["WaitForIP"] = False
+    return options
+
+
+# --------------------------------------------------------------------------- #
+# Atomic claim (Setting.name is unique -> INSERT is the lock)
+# --------------------------------------------------------------------------- #
+def lock_name(endpoint_id, uid):
+    return f"{LOCK_PREFIX}{endpoint_id}_{uid}"
+
+
+def try_claim(endpoint_id, uid) -> bool:
+    name = lock_name(endpoint_id, uid)
+    with database.get_session_ctx() as session:
+        session.add(
+            M.Setting(name=name, description="ova staging in-progress lock", value="1")
+        )
+        try:
+            session.commit()
+            return True
+        except IntegrityError:
+            session.rollback()
+            return False
+
+
+def release_claim(endpoint_id, uid):
+    name = lock_name(endpoint_id, uid)
+    with database.get_session_ctx() as session:
+        row = session.exec(select(M.Setting).where(M.Setting.name == name)).one_or_none()
+        if row is not None:
+            session.delete(row)
+            session.commit()

--- a/zpodengine/src/zpodengine/lib/ovfdeployer.py
+++ b/zpodengine/src/zpodengine/lib/ovfdeployer.py
@@ -105,6 +105,38 @@ def ovf_deployer(zpod_component: M.ZpodComponent):
     print("govc ovf property options generated file")
     print(json.dumps(json.loads(govc_spec_render), indent=2))
 
+    # FF (Feature Flag): stage the OVA once into a VM Template and clone it for
+    # every subsequent L1 deployment instead of re-uploading it each time.
+    # Only L1 components (component_isnested is False) land on the endpoint
+    # vCenter. Any failure falls back to the direct OVA import below.
+    if (
+        isnested is False
+        and DBUtils.get_setting_value("ff_endpoint_ova_staging") == "true"
+    ):
+        try:
+            from zpodengine.lib.ova_staging import deploy_from_template
+
+            deploy_from_template(
+                zpod=zpod,
+                component=component,
+                compute=zpod.endpoint.endpoints["compute"],
+                govc_spec=govc_spec,
+                real_property_values={
+                    pm["Key"]: pm["Value"]
+                    for pm in json.loads(govc_spec_render).get("PropertyMapping", [])
+                },
+                vm_name=vm_name,
+                vapp_pool_name=resource_pool,
+                portgroup_name=zpod_portgroup,
+                govc_url=url,
+            )
+            return
+        except Exception as e:
+            print(
+                "[ff_endpoint_ova_staging] staging/clone failed, falling back to "
+                f"direct OVA import: {e}"
+            )
+
     options_filename = f"/tmp/{zpod_component.fqdn}.json"
     with open(options_filename, "w") as f:
         f.write(govc_spec_render)


### PR DESCRIPTION
…ploy

Behind the ff_endpoint_ova_staging feature flag (off by default). Avoids re-uploading an L1 OVA from the zPodFactory host to the endpoint vCenter on every deployment: upload each OVA once into <vmfolder>/components-staging as a VM Template, then clone it per zPod, injecting the per-zPod OVF properties and portgroup at clone time. Turns a network-bound upload into an endpoint-local clone.

Only applies to L1 components (component_isnested is False); the template is never powered on (that would consume the one-shot OVF customization). Any failure falls back to the existing direct govc import.ova path, so behavior with the flag off is unchanged.

zpodcommon/lib/vmware.py - new vCenter methods:
- clone_template(): clone a template into a pool/datastore/folder, overriding vApp/OVF property values (matched by fully-qualified OVF key [classId.]id[.instanceId], e.g. vami.ip0.SDDC-Manager) and remapping all NICs to the zPod segment (NSX opaque / DVPG / standard backings).
- get_folder / get_or_create_folder / inventory_path, get_network, mark_as_template, get/set_custom_field, network_backing.
- create_vapp now reuses get_folder (de-duplicated folder lookup).

zpodengine/lib/ova_staging.py - staging orchestration:
- One-time govc import.ova into components-staging as a VM Template named by component_uid, with neutral values and PowerOn=False.
- Concurrency: an atomic DB claim (unique Setting row) elects a single stager; a "staged" custom attribute lets sibling deploys wait; a crashed stager is transparently taken over. Idempotent throughout.

zpodengine/lib/ovfdeployer.py - gate ovf_deployer() on the flag + L1, with fallback to the direct import path.