### PR TITLE
zcore: rename the mandatory core component (zbox -> zcore)

### DIFF
--- a/justfile
+++ b/justfile
@@ -242,6 +242,10 @@ zpodcore-start-background $COLUMNS=rich_cols:
 zpodcore-stop:
   docker compose down
 
+# Migrate all profiles from zbox-* to the new zcore component
+zcore-transition:
+  @bash misc/zcore-transition.sh
+
 # Deploy all Flows
 zpodengine-deploy-all:
   just zpodengine-prefect --no-prompt deploy --all

--- a/misc/zcore-transition.sh
+++ b/misc/zcore-transition.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# zcore-transition.sh — switch all profiles from the legacy `zbox-*` core
+# component to `zcore-13.5`, so every *new* zPod deploys `zcore`.
+#
+# For every profile whose first component (the core) is a `zbox-*`, it uses the
+# standard zcli edit flow:
+#     just zcli profile info <name> -j > <file>     # current profile json
+#     # rewrite the first component zbox-<ver> -> zcore-13.5 (+ hostname)
+#     just zcli profile update <name> -pf <file>
+#
+# Plus: resync the library and enable the zcore component first.
+#
+# Idempotent (profiles already on zcore are skipped); requires `jq`. The zpodapi
+# stack must be UP (zcli is an HTTP client). Typical use, after upgrading:
+#     just zpodcore-stop && git pull && just zpodcore-start-background
+#     # wait for zpodapi to be healthy, then:
+#     just zcore-transition                  # = bash misc/zcore-transition.sh
+#
+set -euo pipefail
+
+ZCORE_UID="${ZCORE_UID:-zcore-13.5}"
+LIBRARY="${LIBRARY:-default}"
+WAIT_TIMEOUT="${WAIT_TIMEOUT:-3600}"   # max seconds to wait for the OVA download
+WAIT_POLL="${WAIT_POLL:-15}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+zcli() {
+  if command -v just >/dev/null 2>&1; then
+    ( cd "$ROOT" && just zcli "$@" )
+  else
+    ( cd "$ROOT" && uv --project zpodcli run zcli "$@" )
+  fi
+}
+
+command -v jq >/dev/null 2>&1 || { echo "ERROR: jq is required" >&2; exit 1; }
+
+echo "==> Resyncing library '${LIBRARY}' (fetches '${ZCORE_UID}')..."
+zcli library resync "${LIBRARY}"
+
+echo "==> Enabling component '${ZCORE_UID}'..."
+if ! zcli component enable "${ZCORE_UID}"; then
+  echo "ERROR: could not enable '${ZCORE_UID}'. Is it present in library" \
+       "'${LIBRARY}' after resync? Aborting." >&2
+  exit 1
+fi
+
+# Enable only schedules the download; the component flips to ACTIVE once the OVA
+# is downloaded and verified. Wait for that before rewriting profiles (profile
+# validation also requires the component to be ACTIVE).
+echo "==> Waiting for '${ZCORE_UID}' to become ACTIVE (downloading the OVA)..."
+deadline=$(( SECONDS + WAIT_TIMEOUT ))
+while :; do
+  status="$(zcli component list -j 2>/dev/null \
+    | jq -r --arg uid "${ZCORE_UID}" '.[] | select(.component_uid == $uid) | .status' \
+    | head -n1)"
+  if [ "${status}" = "ACTIVE" ]; then
+    echo "    '${ZCORE_UID}' is ACTIVE."
+    break
+  fi
+  if [ "${SECONDS}" -ge "${deadline}" ]; then
+    echo "ERROR: timed out after ${WAIT_TIMEOUT}s waiting for '${ZCORE_UID}' to" \
+         "become ACTIVE (last status: '${status:-<none>}')." >&2
+    exit 1
+  fi
+  echo "    status='${status:-<none>}', waiting ${WAIT_POLL}s..."
+  sleep "${WAIT_POLL}"
+done
+
+echo "==> Migrating profiles ('zbox-*' first component -> '${ZCORE_UID}')..."
+mapfile -t profiles < <(zcli profile list -j 2>/dev/null | jq -r '.[].name')
+
+if [ "${#profiles[@]}" -eq 0 ]; then
+  echo "No profiles found."
+  exit 0
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+changed=0
+for name in "${profiles[@]}"; do
+  [ -n "${name}" ] || continue
+  f="${tmpdir}/${name}.json"
+
+  if ! zcli profile info "${name}" -j > "${f}" 2>/dev/null; then
+    echo "    - ${name}: 'profile info' failed, skipping"
+    continue
+  fi
+
+  # The core component is the first element of the profile.
+  if ! jq -e '(.[0].component_uid // "") | startswith("zbox-")' "${f}" >/dev/null; then
+    echo "    - ${name}: first component is not zbox, skipping"
+    continue
+  fi
+
+  jq --arg uid "${ZCORE_UID}" '
+    .[0].component_uid = $uid
+    | (if .[0].hostname == "zbox" then .[0].hostname = "zcore" else . end)
+  ' "${f}" > "${f}.new" && mv "${f}.new" "${f}"
+
+  zcli profile update "${name}" -pf "${f}"
+  echo "    - ${name}: updated -> ${ZCORE_UID}"
+  changed=$((changed + 1))
+done
+
+echo "==> Done. ${changed} profile(s) migrated to '${ZCORE_UID}'."
+echo "    New zPods will now deploy '${ZCORE_UID}'. Existing zPods are unchanged."

--- a/zpodapi/src/zpodapi/profiles/profile__schemas.py
+++ b/zpodapi/src/zpodapi/profiles/profile__schemas.py
@@ -16,9 +16,9 @@ class D:
     last_modified_date = {"example": example_creation_date}
 
     class profile:
-        component_uid = {"example": "zbox-11.7"}
+        component_uid = {"example": "zcore-13.5"}
         host_id = {"example": 11}
-        hostname = {"example": "zbox"}
+        hostname = {"example": "zcore"}
         vcpu = {"example": 4}
         vmem = {"example": 12}
         vnics = {"example": 4}

--- a/zpodapi/src/zpodapi/profiles/profile__utils.py
+++ b/zpodapi/src/zpodapi/profiles/profile__utils.py
@@ -39,6 +39,16 @@ def validate_profile(session: Session, profile_obj: list):
         elif components.get(component_uid) != ComponentStatus.ACTIVE:
             errors.append(f"Component is not ACTIVE: {component_uid}")
 
+    # The mandatory core component (zcore-*) must be the first element.
+    first = profile_obj[0] if profile_obj else None
+    if not isinstance(first, dict) or not str(
+        first.get("component_uid", "")
+    ).startswith("zcore-"):
+        errors.append(
+            "Profile must start with a zcore-* core component as its "
+            "first element (legacy zbox profiles must be migrated first)"
+        )
+
     if errors:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/zpodcli/src/zpodcli/cmd/profile_cli.py
+++ b/zpodcli/src/zpodcli/cmd/profile_cli.py
@@ -61,13 +61,35 @@ def profile_item_output(profile):
 
 @app.command(name="list")
 @unexpected_status_handler
-def profile_list():
+def profile_list(
+    json_: Annotated[
+        bool,
+        typer.Option(
+            "--json",
+            "-j",
+            help="Display using json",
+            is_flag=True,
+        ),
+    ] = False,
+    no_color: Annotated[
+        bool,
+        typer.Option(
+            "--no-color",
+            help="Disable color output",
+            is_flag=True,
+        ),
+    ] = False,
+):
     """
     Profile List
     """
     z: ZpodClient = ZpodClient()
     profiles = z.profiles_get_all.sync()
-    generate_table(profiles, "List")
+    if json_:
+        profiles_dict = [profile.to_dict() for profile in profiles]
+        json_print(profiles_dict, no_color=no_color)
+    else:
+        generate_table(profiles, "List")
 
 
 @app.command(name="info", no_args_is_help=True)

--- a/zpodcli/src/zpodcli/cmd/zpod_cli.py
+++ b/zpodcli/src/zpodcli/cmd/zpod_cli.py
@@ -318,7 +318,7 @@ def zpod_create(
             for esxi in component:
                 component_order.append((esxi.component_uid, esxi.hostname))
         else:
-            # Handle single components like zbox
+            # Handle single components like zcore
             component_order.append(component.component_uid)
 
     ep: EndpointViewFull = z.endpoints_get.sync(id=f"name={endpoint}")

--- a/zpodcli/src/zpodcli/cmd/zpod_info_cli.py
+++ b/zpodcli/src/zpodcli/cmd/zpod_info_cli.py
@@ -3,9 +3,7 @@ from ipaddress import IPv4Network
 from typing import Annotated
 
 import typer
-from rich import print
 from rich.console import Group
-from rich.json import JSON
 from rich.panel import Panel
 from rich.table import Table, box
 
@@ -27,12 +25,12 @@ def generate_detailed_info(zpod: ZpodView, fields: str = "bnc"):
                n - Networks
                c - Components
     """
-    # Find zbox component and get its IP once for all networks
-    zbox_component = next(
-        (comp for comp in zpod.components if comp.component.component_name == "zbox"),
+    # Find the zcore component and get its IP once for all networks
+    zcore_component = next(
+        (c for c in zpod.components if c.component.component_name == "zcore"),
         None,
     )
-    zbox_ip = zbox_component.ip if zbox_component else "Not found"
+    zcore_ip = zcore_component.ip if zcore_component else "Not found"
 
     # Get full endpoint information
     z: ZpodClient = ZpodClient()
@@ -113,7 +111,7 @@ def generate_detailed_info(zpod: ZpodView, fields: str = "bnc"):
             vlan_id = int(network_part.split(".")[-1])
             vlan_display = "None (Untagged)" if vlan_id == 0 else str(vlan_id)
             router = (
-                "zPodFactory Endpoint NSX-T1" if vlan_id == 0 else f"zbox.{zpod.domain}"
+                "zPodFactory Endpoint NSX-T1" if vlan_id == 0 else f"zcore.{zpod.domain}"
             )
             # Calculate netmask from prefix length
             netmask = str(ipv4network.netmask)
@@ -121,33 +119,24 @@ def generate_detailed_info(zpod: ZpodView, fields: str = "bnc"):
                 f"[bold]{network.cidr}[/bold]",
                 f"[cornflower_blue]{netmask}[/cornflower_blue]",
                 gateway,
-                f"{zbox_ip} [sky_blue2](zbox)[/sky_blue2]",
+                f"{zcore_ip} [sky_blue2](zcore)[/sky_blue2]",
                 f"[cornflower_blue]{vlan_display}[/cornflower_blue]",
                 f"[dark_khaki]{router}[/dark_khaki]",
             )
 
-        # Get the first network for NSX-T1 and zbox eth0
+        # Get the first network for NSX-T1 and zcore (eth0)
         nsx_network = zpod.networks[0]
         nsx_ipv4network = IPv4Network(nsx_network.cidr)
         nsx_gateway = str(nsx_ipv4network.network_address + 1)
 
-        # Get zbox IP
-        zbox_component = next(
-            (
-                comp
-                for comp in zpod.components
-                if comp.component.component_name == "zbox"
-            ),
-            None,
-        )
-        zbox_ip = zbox_component.ip if zbox_component else "N/A"
+        # zcore_ip already resolved above
 
         # Create static routes text
         static_routes = []
         for network in zpod.networks:
             if int(network.cidr.split("/")[0].split(".")[-1]) != 0:  # Skip native VLAN
                 static_routes.append(
-                    f"        ║      - [sky_blue2]{network.cidr}[/sky_blue2] to [yellow3]{zbox_ip}[/yellow3] ([yellow3]zbox[/yellow3])"
+                    f"        ║      - [sky_blue2]{network.cidr}[/sky_blue2] to [yellow3]{zcore_ip}[/yellow3] ([yellow3]zcore[/yellow3])"
                 )
 
         # Calculate T0 box width based on T0 value and header text
@@ -183,22 +172,22 @@ def generate_detailed_info(zpod: ZpodView, fields: str = "bnc"):
  └{"─" * t1_width}┘
         ║`- [sky_blue2]{nsx_gateway}/{nsx_ipv4network.prefixlen}[/sky_blue2] (zPod Management Network)
         ║
-        ║     NSX-T1 Static routes to [yellow3]zbox[/yellow3] connected interface ([yellow3]eth0[/yellow3])
+        ║     NSX-T1 Static routes to [yellow3]zcore[/yellow3] connected interface ([yellow3]eth0[/yellow3])
 {chr(10).join(static_routes)}
         ║
         ║ [dark_sea_green4]zPod-{zpod.name}-segment[/dark_sea_green4] ([cyan]{endpoint.endpoints.network.transportzone}[/cyan])
         ║ - This NSX Segment carries VLANs [magenta]\\[0-4094][/magenta] (802.1Q Trunk)
         ║ """
 
-        # Calculate zbox box width based on content
-        zbox_header = "zbox"
+        # Calculate zcore box width based on content
+        zcore_header = "zcore"
         # Calculate width based only on interface names
         interface_names = ["eth0", "eth1.64", "eth1.128", "eth1.192"]
         max_interface_width = (
             max(len(name) for name in interface_names) + 8
         )  # Add padding
-        zbox_width = max(
-            len(zbox_header) + 8,  # Header + padding
+        zcore_width = max(
+            len(zcore_header) + 8,  # Header + padding
             max_interface_width,  # Interface names + padding
             15,  # Minimum width
         )
@@ -209,7 +198,7 @@ def generate_detailed_info(zpod: ZpodView, fields: str = "bnc"):
             ipv4network = IPv4Network(network.cidr)
             if int(network.cidr.split("/")[0].split(".")[-1]) == 0:
                 # For eth0
-                ip_lengths.append(len(f"{zbox_ip}/{ipv4network.prefixlen}"))
+                ip_lengths.append(len(f"{zcore_ip}/{ipv4network.prefixlen}"))
             else:
                 # For eth1.X
                 gateway = str(ipv4network.network_address + 1)
@@ -223,7 +212,7 @@ def generate_detailed_info(zpod: ZpodView, fields: str = "bnc"):
             gateway = str(ipv4network.network_address + 1)
             vlan_id = int(network.cidr.split("/")[0].split(".")[-1])
             if vlan_id == 0:
-                ip_str = f"{zbox_ip}/{ipv4network.prefixlen}"
+                ip_str = f"{zcore_ip}/{ipv4network.prefixlen}"
                 interface_info.append(
                     f" │ [yellow3]eth0[/yellow3]           │ - [yellow3]{ip_str}{' ' * (max_ip_length - len(ip_str))}[/yellow3] [cornflower_blue](None - Untagged)[/cornflower_blue]"
                 )
@@ -233,12 +222,12 @@ def generate_detailed_info(zpod: ZpodView, fields: str = "bnc"):
                     f" │ eth1.[cornflower_blue]{vlan_id:<6}[/cornflower_blue]    │ - [sky_blue2]{ip_str}{' ' * (max_ip_length - len(ip_str))}[/sky_blue2] [cornflower_blue](VLAN {vlan_id})[/cornflower_blue]"
                 )
 
-        # Create the zbox box with just the interface names
-        zbox_box = f""" ┌{"─" * zbox_width}┐
- │ {zbox_header:^{zbox_width - 2}} │
- │ {" " * (zbox_width - 2)} │
+        # Create the zcore box with just the interface names
+        zcore_box = f""" ┌{"─" * zcore_width}┐
+ │ {zcore_header:^{zcore_width - 2}} │
+ │ {" " * (zcore_width - 2)} │
 {chr(10).join(interface_info)}
- └{"─" * zbox_width}┘"""
+ └{"─" * zcore_width}┘"""
 
         networks_panel = Panel(
             Group(
@@ -247,7 +236,7 @@ def generate_detailed_info(zpod: ZpodView, fields: str = "bnc"):
                 "\nzPod Network Diagram:",
                 t0_box,
                 t1_box,
-                zbox_box,
+                zcore_box,
             ),
             title="Networks",
             border_style="yellow",

--- a/zpodcommon/src/zpodcommon/lib/network_utils.py
+++ b/zpodcommon/src/zpodcommon/lib/network_utils.py
@@ -8,7 +8,7 @@ from zpodcommon.lib.zboxapi import RequestError, ZboxApiClient
 class MgmtIp:
     MGMT_HOST_IDS = {
         "gw": 1,
-        "zbox": 2,
+        "zcore": 2,
         "zrdp": 3,
         "hcx-cloud": 7,
         "hcx-connector": 8,

--- a/zpodcommon/src/zpodcommon/lib/vmware.py
+++ b/zpodcommon/src/zpodcommon/lib/vmware.py
@@ -537,7 +537,7 @@ class vCenter:
         # sourcery skip: class-extract-method
         # Fetch VM
         # For this example:
-        # zbox.{instance_name}.{domain}
+        # zcore.{instance_name}.{domain}
         spec = vim.vm.ConfigSpec()
         spec.cpuAllocation = vim.ResourceAllocationInfo()
         spec.cpuAllocation.shares = vim.SharesInfo()

--- a/zpodcommon/src/zpodcommon/lib/zboxapi.py
+++ b/zpodcommon/src/zpodcommon/lib/zboxapi.py
@@ -106,7 +106,7 @@ class ZboxApiClient(httpx.Client):
         **kwargs,
     ):
         return cls(
-            zbox_url=f"{protocol}://zbox.{zpod.domain}:{port}{root_path}",
+            zbox_url=f"{protocol}://zcore.{zpod.domain}:{port}{root_path}",
             zbox_password=zpod.password,
             **kwargs,
         )

--- a/zpodcommon/src/zpodcommon/models/component_models.py
+++ b/zpodcommon/src/zpodcommon/models/component_models.py
@@ -75,7 +75,7 @@ class Component(CommonDatesMixin, ModelBase, table=True):
                 usernames.append({"username": "admin", "type": "ui"})
             case "vrops":
                 usernames.append({"username": "admin", "type": "ui"})
-            case "vyos" | "zbox" | _:
+            case "vyos" | "zbox" | "zcore" | _:
                 pass
 
         return usernames

--- a/zpodcommon/tests/test_network_utils.py
+++ b/zpodcommon/tests/test_network_utils.py
@@ -15,6 +15,6 @@ def test_mgmt_ip_arithmetic():
 
 def test_mgmt_ip_known_host_ids():
     assert MgmtIp.MGMT_HOST_IDS["gw"] == 1
-    assert MgmtIp.MGMT_HOST_IDS["zbox"] == 2
+    assert MgmtIp.MGMT_HOST_IDS["zcore"] == 2
     assert MgmtIp.MGMT_HOST_IDS["vcsa"] == 10
     assert MgmtIp.MGMT_HOST_IDS["nsxt"] == 20

--- a/zpodengine/scripts/powershell/post-scripts/esxi_configure.ps1
+++ b/zpodengine/scripts/powershell/post-scripts/esxi_configure.ps1
@@ -1,6 +1,6 @@
 Param (
     [String]$zPodHostname = $(throw "-zPodHostname required"),
-    [string]$zBoxHostname = $(throw "-zBoxHostname required"),
+    [string]$zCoreHostname = $(throw "-zCoreHostname required"),
     [string]$zPodFactory = $(throw "-zPodFactory required"),
     [String]$zPodPassword = $(throw "-zPodPassword required")
 )
@@ -16,7 +16,7 @@ $LIB_DIR = "/zpodengine/scripts/powershell/lib"
 Retry-Command -ScriptBlock { Connect-VIServer -Server $zPodHostname -User root -Password $zPodPassword }
 
 # NFS
-Retry-Command -ScriptBlock { Get-VMHost | New-Datastore -NFS -Name "NFS-01" -Path "/FILER/STORAGE01/NFS-01" -NfsHost $zBoxHostname }
+Retry-Command -ScriptBlock { Get-VMHost | New-Datastore -NFS -Name "NFS-01" -Path "/FILER/STORAGE01/NFS-01" -NfsHost $zCoreHostname }
 
 # Set to Connected (not maintenance mode)
 Retry-Command -ScriptBlock { Get-VMHost | Set-VMHost -State "Connected" | Out-Null }

--- a/zpodengine/src/zpodengine/lib/network.py
+++ b/zpodengine/src/zpodengine/lib/network.py
@@ -60,14 +60,14 @@ def get_zpod_primary_subnet(endpoint: str):
 # We defaulted each of them to a /26 network
 # This means we will have 4 x /26 usable in the zPod
 # The first /26 will be managed by the Native VDS/NSX-T Segment
-# The last 3 x /26 will be managed by zbox/vyos through guest VLANs
+# The last 3 x /26 will be managed by zcore/vyos through guest VLANs
 # Example:
 # zpod_subnet = 10.96.50.0/24
 # provides:
 # - 10.96.50.0/26   [VDS/NSX-T on native vlan (no tagging)]
-# - 10.96.50.64/26  [zbox/vyos on vlan 64]
-# - 10.96.50.128/26 [zbox/vyos on vlan 128]
-# - 10.96.50.192/26 [zbox/vyos on vlan 192]
+# - 10.96.50.64/26  [zcore/vyos on vlan 64]
+# - 10.96.50.128/26 [zcore/vyos on vlan 128]
+# - 10.96.50.192/26 [zcore/vyos on vlan 192]
 #
 
 

--- a/zpodengine/src/zpodengine/lib/ovfdeployer.py
+++ b/zpodengine/src/zpodengine/lib/ovfdeployer.py
@@ -26,15 +26,15 @@ def ovf_deployer(zpod_component: M.ZpodComponent):
     zpodfactory_host = DBUtils.get_setting_value("zpodfactory_host")
     zpodfactory_ssh_key = DBUtils.get_setting_value("zpodfactory_ssh_key")
 
-    if component.component_name in ["zbox", "vyos"]:
-        # zpodfactory is the main DNS server for every zpod and links to zbox/vyos
+    if component.component_name in ("zcore", "vyos"):
+        # zpodfactory is the main DNS server for every zpod and links to zcore/vyos
         # as DNS servers for their respective subdomain.
         #
         # For those 2 components, the DNS Server must be the zpodfactory_host.
         zpod_dns = zpodfactory_host
     else:
-        # all other components rely on zbox/vyos as their DNS server.
-        zpod_dns = MgmtIp.zpod(zpod, "zbox").ip
+        # all other components rely on zcore/vyos as their DNS server.
+        zpod_dns = MgmtIp.zpod(zpod, "zcore").ip
 
     isnested = component.component_json["component_isnested"]
     print(f"Component Nested: {isnested}")
@@ -71,8 +71,8 @@ def ovf_deployer(zpod_component: M.ZpodComponent):
         zpod_portgroup = "VM Network"
         vm_name = zpod_component.hostname
 
-    # Add zbox as this is a mandatory infrastructure component
-    zpod_zbox_ipaddress = MgmtIp.zpod(zpod, "zbox").ip
+    # Add the core component (zcore) as a mandatory infrastructure component
+    zpod_zcore_ipaddress = MgmtIp.zpod(zpod, "zcore").ip
     url = f"https://{username}:{password}@{hostname}/sdk"
     print(f"Deploying to [https://{username}:XXXXXXXX@{hostname}/sdk]...")
 
@@ -94,7 +94,7 @@ def ovf_deployer(zpod_component: M.ZpodComponent):
         zpod_netprefix=ZPOD_PUBLIC_SUB_NETWORKS_PREFIXLEN,
         zpod_gateway=component_gateway,
         zpod_dns=zpod_dns,
-        zpod_nfs=zpod_zbox_ipaddress,
+        zpod_nfs=zpod_zcore_ipaddress,
         zpod_ntp=zpodfactory_host,
         zpod_domain=zpod.domain,
         zpod_password=zpod.password,

--- a/zpodengine/src/zpodengine/zpod_component_add/zpod_component_add_2_pre_scripts.py
+++ b/zpodengine/src/zpodengine/zpod_component_add/zpod_component_add_2_pre_scripts.py
@@ -19,7 +19,7 @@ def zpod_component_add_pre_scripts(
         zpod_component = session.get(M.ZpodComponent, zpod_component_id)
 
         c = zpod_component.component
-        if c.component_name != "zbox":
+        if c.component_name != "zcore":
             zb = ZboxApiClient.by_zpod(zpod_component.zpod)
             try:
                 response = zb.post(

--- a/zpodengine/src/zpodengine/zpod_component_add/zpod_component_add_3_deploy.py
+++ b/zpodengine/src/zpodengine/zpod_component_add/zpod_component_add_3_deploy.py
@@ -28,8 +28,8 @@ def zpod_component_add_deploy(
         print(component)
 
         match component.component_name:
-            case "zbox":
-                print("--- zbox ---")
+            case "zcore":
+                print("--- zcore ---")
 
                 ovf_deployer(zpod_component)
 
@@ -108,7 +108,17 @@ def zpod_component_add_deploy(
                 print("--- Normal Component ---")
                 ovf_deployer(zpod_component)
 
-                with vCenter.auth_by_zpod(zpod=zpod_component.zpod) as vc:
-                    vm = vc.get_vm(name=zpod_component.hostname)
-                    print("Start VM")
-                    vc.poweron_vm(vm)
+                isnested = component.component_json["component_isnested"]
+                print(f"Component Nested: {isnested}")
+
+                if isnested:
+                    with vCenter.auth_by_zpod(zpod=zpod_component.zpod) as vc:
+                        vm = vc.get_vm(name=zpod_component.hostname)
+                        print("Start VM")
+                        vc.poweron_vm(vm)
+                else:
+                    with vCenter.auth_by_zpod_endpoint(zpod=zpod_component.zpod) as vc:
+                        vm = vc.get_vm(name=zpod_component.fqdn)
+                        print("Start VM")
+                        vc.poweron_vm(vm)
+

--- a/zpodengine/src/zpodengine/zpod_component_add/zpod_component_add_4_post_scripts.py
+++ b/zpodengine/src/zpodengine/zpod_component_add/zpod_component_add_4_post_scripts.py
@@ -31,8 +31,8 @@ def zpod_component_add_post_scripts(*, zpod_component_id: int):
 
         # Specific behavior for critical zpod components
         match component.component_name:
-            case "zbox":
-                print("--- zbox ---")
+            case "zcore":
+                print("--- zcore ---")
                 # Add static routes on NSX T1 unless using vyos below
 
                 # Wait until zboxapi is ready
@@ -48,9 +48,9 @@ def zpod_component_add_post_scripts(*, zpod_component_id: int):
                         print(f"Waiting for {e.request.url} to start.")
                         time.sleep(15)
 
-                # Would prefer to raise an error here, but we need to support old
-                # zbox versions
-                print("DNS startup failure.  Skipping...")
+                raise RuntimeError(
+                    "zcore DNS (zboxapi /dns) did not become ready within 180s"
+                )
 
             case "vyos":
                 print("--- vyos ---")
@@ -115,7 +115,7 @@ def zpod_component_add_post_scripts(*, zpod_component_id: int):
                 cmd = (
                     f"/zpodengine/scripts/powershell/post-scripts/esxi_configure.ps1"
                     f" -zPodHostname {zpod_component.fqdn}"
-                    f" -zBoxHostname zbox.{zpod.domain}"
+                    f" -zCoreHostname zcore.{zpod.domain}"
                     f" -zPodFactory {zpodfactory_host}.{zpod.domain}"
                     f" -zPodPassword {zpod.password}"
                 )

--- a/zpodengine/src/zpodengine/zpod_deploy/networking_deploy_nsxt.py
+++ b/zpodengine/src/zpodengine/zpod_deploy/networking_deploy_nsxt.py
@@ -94,7 +94,7 @@ def networking_deploy_nsxt(zpod: M.Zpod, enet_name: str | None = None):
         )
 
         # Create Segment Security Profile
-        # - Allow DHCP Server on Segment such as zbox/vyos
+        # - Allow DHCP Server on Segment such as zcore/vyos
         segment_security_profile_id = f"{inst_prefix}-segment-security-profile"
         print(f"Create Segment Security Profile: {segment_security_profile_id}")
         nsx.patch(
@@ -138,7 +138,7 @@ def networking_deploy_nsxt(zpod: M.Zpod, enet_name: str | None = None):
                     "network": network.cidr,
                     "next_hops": [
                         {
-                            "ip_address": MgmtIp.zpod(zpod, "zbox").ip,
+                            "ip_address": MgmtIp.zpod(zpod, "zcore").ip,
                             "admin_distance": 1,
                         },
                     ],

--- a/zpodengine/src/zpodengine/zpod_deploy/networking_deploy_nsxt_project.py
+++ b/zpodengine/src/zpodengine/zpod_deploy/networking_deploy_nsxt_project.py
@@ -115,7 +115,7 @@ def networking_deploy_nsxt_project(zpod: M.Zpod, enet_name: str | None = None):
         )
 
         # Create Segment Security Profile
-        # - Allow DHCP Server on Segment such as zbox/vyos
+        # - Allow DHCP Server on Segment such as zcore/vyos
         segment_security_profile_id = f"{project_prefix}-segment-security-profile"
         print(f"Create Segment Security Profile: {segment_security_profile_id}")
         nsx.patch(
@@ -182,7 +182,7 @@ def networking_deploy_nsxt_project(zpod: M.Zpod, enet_name: str | None = None):
                     "network": network.cidr,
                     "next_hops": [
                         {
-                            "ip_address": MgmtIp.zpod(zpod, "zbox").ip,
+                            "ip_address": MgmtIp.zpod(zpod, "zcore").ip,
                             "admin_distance": 1,
                         },
                     ],

--- a/zpodengine/src/zpodengine/zpod_deploy/zpod_deploy_2_dnsmasq.py
+++ b/zpodengine/src/zpodengine/zpod_deploy/zpod_deploy_2_dnsmasq.py
@@ -12,8 +12,8 @@ def zpod_deploy_dnsmasq(zpod_id: int):
     with database.get_session_ctx() as session:
         zpod = session.get(M.Zpod, zpod_id)
 
-        # Fetch associate zbox IP from subnet
-        dns_ip = MgmtIp.zpod(zpod, "zbox").ip
+        # Fetch the core component IP from subnet
+        dns_ip = MgmtIp.zpod(zpod, "zcore").ip
 
         # Create dnsmasq configuration
         dnsmasq.add(zpod.domain, dns_ip)


### PR DESCRIPTION
Introduce `zcore` as the mandatory core component of every zPod (DNS server, NFS filer, zboxapi host, subnet IP .2), deployed from the packer-zcore appliance. New zPods deploy zcore; the `zbox` name is freed to become an ordinary multi-deploy component.

- network_utils: MGMT_HOST_IDS["zcore"] = 2; dropped the legacy "zbox" slot.
- Deployment treats only `zcore` as core (dispatch, ovfdeployer DNS self-config, pre-script DNS-skip); a `zbox` component deploys as an ordinary component.
- zboxapi endpoint + esxi NFS host use zcore.{domain} directly (no core_component module).
- Profile validation requires a zcore-* first component; `zcli profile list -j`; examples and `zpod info` show the actual core.
- L1/L2 nesting + physical-vs-nested vCenter endpoint handling.
- misc/zcore-transition.sh (+ `just zcore-transition`): resync library, enable zcore-13.5 (wait until ACTIVE), rewrite all profiles zbox-* -> zcore-13.5.